### PR TITLE
Sample layers from WMS are toggle-able from side menu

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -143,12 +143,12 @@
             </div>
             <div class="col-sm-4 col-lg-3 col-xl-2" id="map-control-panel">
                 <div class="map-control-item">
-                    <a data-toggle="collapse" href="#gisLayers" aria-expanded="false" aria-controls="gisLayers">
-                        <h4 class="map-control-item-heading">GIS Layers<i class="fa fa-chevron-down pull-right"
-                                                                          aria-hidden="true"></i></h4>
+                    <a data-toggle="collapse in" href="#gisLayers" aria-expanded="false" aria-controls="gisLayers">
+                        <h4 class="map-control-item-heading">GIS Layers
+                            <i class="fa fa-chevron-down pull-right" aria-hidden="true"></i></h4>
                         <p class="qualifier" style="margin-bottom: 0">for Planning role</p>
                     </a>
-                    <div class="collapse" id="gisLayers">
+                    <div class="collapse in" id="gisLayers">
                         <p class="map-layer-group-heading">
                             <a data-toggle="collapse" href="#baseMapping" aria-expanded="false"
                                aria-controls="baseMapping">
@@ -156,106 +156,103 @@
                             </a>
                         </p>
                         <ul class="collapse map-layers" id="baseMapping">
-                            <li><input type="checkbox" name="gender" value="male"> Imagery</li>
-                            <li><input type="checkbox" name="gender" value="female"> National Hydrography Dataset</li>
-                            <li><input type="checkbox" name="gender" value="male"> National Wetlands Inventory</li>
-                            <li><input type="checkbox" name="gender" value="female"> Shoreline Type</li>
-                            <li><input type="checkbox" name="gender" value="female"> Municipal Boundary</li>
-                            <li><input type="checkbox" name="gender" value="female"> Elevation Contours</li>
-                            <li><input type="checkbox" name="gender" value="female"> Spot Elevations</li>
+                            <li><input id="flowline" type="checkbox" name="gender" value="male"> FLowline - Large Scale</li>
+                            <li><input id="flowdirection" type="checkbox" name="gender" value="male"> Flow Direction</li>
+                            <li><input id="waterbody" type="checkbox" name="gender" value="female"> Waterbody - Small Scale</li>
+                            <li><input id="line" type="checkbox" name="gender" value="male"> Line - Small Scale</li>
                         </ul>
-                        <p class="map-layer-group-heading">
-                            <a data-toggle="collapse" href="#propParcels" aria-expanded="false"
-                               aria-controls="propParcels">
-                                <i class="fa fa-chevron-right" aria-hidden="true"></i> Property & Parcels
-                            </a>
-                        </p>
-                        <ul class="collapse map-layers" id="propParcels">
-                            <li><input type="checkbox" name="gender" value="male"> Parcels</li>
-                            <li><input type="checkbox" name="gender" value="female"> Buildings</li>
-                        </ul>
-                        <p class="map-layer-group-heading">
-                            <a data-toggle="collapse" href="#emergencyOps" aria-expanded="false"
-                               aria-controls="emergencyOps">
-                                <i class="fa fa-chevron-right" aria-hidden="true"></i> Emergency Ops Plan
-                            </a>
-                        </p>
-                        <ul class="collapse map-layers" id="emergencyOps">
-                            <li><input type="checkbox" name="gender" value="male"> Boat Launch</li>
-                            <li><input type="checkbox" name="gender" value="female"> Census Blocks</li>
-                            <li><input type="checkbox" name="gender" value="male"> Critical Facilities
-                                <span>State</span></li>
-                            <li><input type="checkbox" name="gender" value="female"> Critical Facilities
-                                <span>Local</span></li>
-                            <li><input type="checkbox" name="gender" value="female"> Evacuation Routes</li>
-                            <li><input type="checkbox" name="gender" value="female"> High Density Population Areas</li>
-                            <li><input type="checkbox" name="gender" value="female"> Marinas</li>
-                            <li><input type="checkbox" name="gender" value="female"> MEDEVAC Landing Zone</li>
-                            <li><input type="checkbox" name="gender" value="female"> Schools</li>
-                            <li><input type="checkbox" name="gender" value="female"> Cell Towers</li>
-                            <li><input type="checkbox" name="gender" value="female"> Sirens</li>
-                            <li><input type="checkbox" name="gender" value="female"> Demographics
-                                <span>by address</span></li>
-                            <li><input type="checkbox" name="gender" value="female"> Permit Automation</li>
-                            <li><input type="checkbox" name="gender" value="female"> Evacuation Routes</li>
-                            <li><input type="checkbox" name="gender" value="female"> County Special Needs Registration
-                            </li>
-                        </ul>
-                        <p class="map-layer-group-heading">
-                            <a data-toggle="collapse" href="#transportation" aria-expanded="false"
-                               aria-controls="transportation">
-                                <i class="fa fa-chevron-right" aria-hidden="true"></i> Transportation
-                            </a>
-                        </p>
-                        <ul class="collapse map-layers" id="transportation">
-                            <li><input type="checkbox" name="gender" value="male"> Bus Routes/Stops</li>
-                        </ul>
-                        <p class="map-layer-group-heading">
-                            <a data-toggle="collapse" href="#planZoning" aria-expanded="false"
-                               aria-controls="planZoning">
-                                <i class="fa fa-chevron-right" aria-hidden="true"></i> Planning & Zoning
-                            </a>
-                        </p>
-                        <ul class="collapse map-layers" id="planZoning">
-                            <li><input type="checkbox" name="gender" value="male"> Open Space <span>Local</span></li>
-                            <li><input type="checkbox" name="gender" value="female"> Zoning</li>
-                            <li><input type="checkbox" name="gender" value="male"> Areas in Need of Redevelopment</li>
-                            <li><input type="checkbox" name="gender" value="female"> Coastal Area Facility Review Act
-                                Planning Areas
-                            </li>
-                            <li><input type="checkbox" name="gender" value="female"> State Planning Areas <span>State Development and Redevelopment Plan</span>
-                            </li>
-                            <li><input type="checkbox" name="gender" value="female"> Known Contaminated Site List</li>
-                        </ul>
-                        <p class="map-layer-group-heading">
-                            <a data-toggle="collapse" href="#publicWorks" aria-expanded="false"
-                               aria-controls="publicWorks">
-                                <i class="fa fa-chevron-right" aria-hidden="true"></i> Public Works
-                            </a>
-                        </p>
-                        <ul class="collapse map-layers" id="publicWorks">
-                            <li><input type="checkbox" name="gender" value="male"> Bridge Locations</li>
-                            <li><input type="checkbox" name="gender" value="female"> Water Features</li>
-                            <li><input type="checkbox" name="gender" value="male"> Sanitary Sewer Features</li>
-                            <li><input type="checkbox" name="gender" value="female"> Storm Sewer Features</li>
-                            <li><input type="checkbox" name="gender" value="male"> Power/Gas</li>
-                            <li><input type="checkbox" name="gender" value="female"> Water Tank</li>
-                            <li><input type="checkbox" name="gender" value="male"> Traffic Lights</li>
-                            <li><input type="checkbox" name="gender" value="female"> Solar Reverse Meter</li>
-                        </ul>
-                        <p class="map-layer-group-heading">
-                            <a data-toggle="collapse" href="#floodFEMA" aria-expanded="false" aria-controls="floodFEMA">
-                                <i class="fa fa-chevron-right" aria-hidden="true"></i> Flooding/FEMA
-                            </a>
-                        </p>
-                        <ul class="collapse map-layers" id="floodFEMA">
-                            <li><input type="checkbox" name="gender" value="male"> Flood Insurance Rate Map</li>
-                            <li><input type="checkbox" name="gender" value="female"> Hurricane Flood Plain</li>
-                            <li><input type="checkbox" name="gender" value="male"> Repetitive Loss Structures</li>
-                            <li><input type="checkbox" name="gender" value="female"> Substantial Damaged Properties</li>
-                            <li><input type="checkbox" name="gender" value="female"> Elevation Certificates</li>
-                            <li><input type="checkbox" name="gender" value="female"> FEMA Claims Properties</li>
-                        </ul>
+{#                        <p class="map-layer-group-heading">#}
+{#                            <a data-toggle="collapse" href="#propParcels" aria-expanded="false"#}
+{#                               aria-controls="propParcels">#}
+{#                                <i class="fa fa-chevron-right" aria-hidden="true"></i> Property & Parcels#}
+{#                            </a>#}
+{#                        </p>#}
+{#                        <ul class="collapse map-layers" id="propParcels">#}
+{#                            <li><input type="checkbox" name="gender" value="male"> Parcels</li>#}
+{#                            <li><input type="checkbox" name="gender" value="female"> Buildings</li>#}
+{#                        </ul>#}
+{#                        <p class="map-layer-group-heading">#}
+{#                            <a data-toggle="collapse" href="#emergencyOps" aria-expanded="false"#}
+{#                               aria-controls="emergencyOps">#}
+{#                                <i class="fa fa-chevron-right" aria-hidden="true"></i> Emergency Ops Plan#}
+{#                            </a>#}
+{#                        </p>#}
+{#                        <ul class="collapse map-layers" id="emergencyOps">#}
+{#                            <li><input type="checkbox" name="gender" value="male"> Boat Launch</li>#}
+{#                            <li><input type="checkbox" name="gender" value="female"> Census Blocks</li>#}
+{#                            <li><input type="checkbox" name="gender" value="male"> Critical Facilities#}
+{#                                <span>State</span></li>#}
+{#                            <li><input type="checkbox" name="gender" value="female"> Critical Facilities#}
+{#                                <span>Local</span></li>#}
+{#                            <li><input type="checkbox" name="gender" value="female"> Evacuation Routes</li>#}
+{#                            <li><input type="checkbox" name="gender" value="female"> High Density Population Areas</li>#}
+{#                            <li><input type="checkbox" name="gender" value="female"> Marinas</li>#}
+{#                            <li><input type="checkbox" name="gender" value="female"> MEDEVAC Landing Zone</li>#}
+{#                            <li><input type="checkbox" name="gender" value="female"> Schools</li>#}
+{#                            <li><input type="checkbox" name="gender" value="female"> Cell Towers</li>#}
+{#                            <li><input type="checkbox" name="gender" value="female"> Sirens</li>#}
+{#                            <li><input type="checkbox" name="gender" value="female"> Demographics#}
+{#                                <span>by address</span></li>#}
+{#                            <li><input type="checkbox" name="gender" value="female"> Permit Automation</li>#}
+{#                            <li><input type="checkbox" name="gender" value="female"> Evacuation Routes</li>#}
+{#                            <li><input type="checkbox" name="gender" value="female"> County Special Needs Registration#}
+{#                            </li>#}
+{#                        </ul>#}
+{#                        <p class="map-layer-group-heading">#}
+{#                            <a data-toggle="collapse" href="#transportation" aria-expanded="false"#}
+{#                               aria-controls="transportation">#}
+{#                                <i class="fa fa-chevron-right" aria-hidden="true"></i> Transportation#}
+{#                            </a>#}
+{#                        </p>#}
+{#                        <ul class="collapse map-layers" id="transportation">#}
+{#                            <li><input type="checkbox" name="gender" value="male"> Bus Routes/Stops</li>#}
+{#                        </ul>#}
+{#                        <p class="map-layer-group-heading">#}
+{#                            <a data-toggle="collapse" href="#planZoning" aria-expanded="false"#}
+{#                               aria-controls="planZoning">#}
+{#                                <i class="fa fa-chevron-right" aria-hidden="true"></i> Planning & Zoning#}
+{#                            </a>#}
+{#                        </p>#}
+{#                        <ul class="collapse map-layers" id="planZoning">#}
+{#                            <li><input type="checkbox" name="gender" value="male"> Open Space <span>Local</span></li>#}
+{#                            <li><input type="checkbox" name="gender" value="female"> Zoning</li>#}
+{#                            <li><input type="checkbox" name="gender" value="male"> Areas in Need of Redevelopment</li>#}
+{#                            <li><input type="checkbox" name="gender" value="female"> Coastal Area Facility Review Act#}
+{#                                Planning Areas#}
+{#                            </li>#}
+{#                            <li><input type="checkbox" name="gender" value="female"> State Planning Areas <span>State Development and Redevelopment Plan</span>#}
+{#                            </li>#}
+{#                            <li><input type="checkbox" name="gender" value="female"> Known Contaminated Site List</li>#}
+{#                        </ul>#}
+{#                        <p class="map-layer-group-heading">#}
+{#                            <a data-toggle="collapse" href="#publicWorks" aria-expanded="false"#}
+{#                               aria-controls="publicWorks">#}
+{#                                <i class="fa fa-chevron-right" aria-hidden="true"></i> Public Works#}
+{#                            </a>#}
+{#                        </p>#}
+{#                        <ul class="collapse map-layers" id="publicWorks">#}
+{#                            <li><input type="checkbox" name="gender" value="male"> Bridge Locations</li>#}
+{#                            <li><input type="checkbox" name="gender" value="female"> Water Features</li>#}
+{#                            <li><input type="checkbox" name="gender" value="male"> Sanitary Sewer Features</li>#}
+{#                            <li><input type="checkbox" name="gender" value="female"> Storm Sewer Features</li>#}
+{#                            <li><input type="checkbox" name="gender" value="male"> Power/Gas</li>#}
+{#                            <li><input type="checkbox" name="gender" value="female"> Water Tank</li>#}
+{#                            <li><input type="checkbox" name="gender" value="male"> Traffic Lights</li>#}
+{#                            <li><input type="checkbox" name="gender" value="female"> Solar Reverse Meter</li>#}
+{#                        </ul>#}
+{#                        <p class="map-layer-group-heading">#}
+{#                            <a data-toggle="collapse" href="#floodFEMA" aria-expanded="false" aria-controls="floodFEMA">#}
+{#                                <i class="fa fa-chevron-right" aria-hidden="true"></i> Flooding/FEMA#}
+{#                            </a>#}
+{#                        </p>#}
+{#                        <ul class="collapse map-layers" id="floodFEMA">#}
+{#                            <li><input type="checkbox" name="gender" value="male"> Flood Insurance Rate Map</li>#}
+{#                            <li><input type="checkbox" name="gender" value="female"> Hurricane Flood Plain</li>#}
+{#                            <li><input type="checkbox" name="gender" value="male"> Repetitive Loss Structures</li>#}
+{#                            <li><input type="checkbox" name="gender" value="female"> Substantial Damaged Properties</li>#}
+{#                            <li><input type="checkbox" name="gender" value="female"> Elevation Certificates</li>#}
+{#                            <li><input type="checkbox" name="gender" value="female"> FEMA Claims Properties</li>#}
+{#                        </ul>#}
                     </div>
                 </div>
                 <div class="map-control-item">

--- a/templates/map.html
+++ b/templates/map.html
@@ -24,10 +24,16 @@
 
 {% endblock map %}
 
+{#{% block map-controls %}#}
+{##}
+{#{% endblock %}#}
+
 {% block extra_js_bottom %}
     <script>
 
-        var mymap = L.map('mapid').setView([40.4417743, -74.1298643], 13);
+        // Base Map -- Centered on Keansburg, NJ
+
+        var mymap = L.map('mapid').setView([40.4417743, -74.1298643], 12);
 
         L.tileLayer('https://api.tiles.mapbox.com/v4/{id}/{z}/{x}/{y}.png?access_token=pk.eyJ1IjoibWFwYm94IiwiYSI6ImNpejY4NXVycTA2emYycXBndHRqcmZ3N3gifQ.rJcFIG214AriISLbB6B5aw', {
             maxZoom: 18,
@@ -37,5 +43,61 @@
             id: 'mapbox.streets'
         }).addTo(mymap);
 
+        // WMS Tile Layers
+        /*
+        Data: Watershed Boundary Dataset - National Hydrography Overlay Map Service
+              https://catalog.data.gov/dataset/usgs-national-watershed-boundary-dataset-wbd-
+              downloadable-data-collection-national-geospatial-/resource/f55f881d-9de8-471f-9b6b-22cd7a98025d
+        XML: https://services.nationalmap.gov/arcgis/services/nhd/MapServer/WMSServer?request=GetCapabilities&service=WMS
+         */
+
+        var flowline_ls_layer = L.tileLayer.wms('https://services.nationalmap.gov/arcgis/services/nhd/MapServer/WMSServer?', {
+            layers: '3'
+         }).setOpacity(0.5);
+
+        var flowdirection_layer = L.tileLayer.wms('https://services.nationalmap.gov/arcgis/services/nhd/MapServer/WMSServer?',{
+            layers: '9'
+         }).setOpacity(0.5);
+
+        var waterbody_ss_layer = L.tileLayer.wms('https://services.nationalmap.gov/arcgis/services/nhd/MapServer/WMSServer?',{
+            layers: '8'
+         }).setOpacity(0.5);
+
+        var line_ss_layer = L.tileLayer.wms('https://services.nationalmap.gov/arcgis/services/nhd/MapServer/WMSServer?',{
+            layers: '2'
+         }).setOpacity(0.5);
+
+
+        $('#flowline').click(function () {
+            if ($(this).is(':checked')) {
+            flowline_ls_layer.addTo(mymap);
+            } else {
+                mymap.removeLayer(flowline_ls_layer)
+            }
+         });
+
+        $('#flowdirection').click(function () {
+            if ($(this).is(':checked')) {
+            flowdirection_layer.addTo(mymap);
+            } else {
+                mymap.removeLayer(flowdirection_layer)
+            }
+         });
+
+        $('#waterbody').click(function () {
+            if ($(this).is(':checked')) {
+            waterbody_ss_layer.addTo(mymap);
+            } else {
+                mymap.removeLayer(waterbody_ss_layer)
+            }
+         });
+
+        $('#line').click(function () {
+            if ($(this).is(':checked')) {
+            line_ss_layer.addTo(mymap);
+            } else {
+                mymap.removeLayer(line_ss_layer)
+            }
+         });
     </script>
 {% endblock extra_js_bottom %}


### PR DESCRIPTION
WMS Tile Layers are acquired from this server:
[https://services.nationalmap.gov/arcgis/services/nhd/MapServer/WMSServer?](https://services.nationalmap.gov/arcgis/services/nhd/MapServer/WMSServer?)

The layer ids are found in the <Name> tag of the XML.
For this proof of concept, I used the following layers:

- Flowline (Large Scale)
- Flow Direction
- Waterbody (Small Scale)
- Line (Small Scale)

**NOTE**: To see these layers requires different zoom levels. The map is centered on Keansburg. Flow Direction and Flowline require zooming in to Keansburg. Waterbody and Line can be seen at the default zoom level.

Sources:

Data: Watershed Boundary Dataset - National Hydrography Overlay Map Service
              https://catalog.data.gov/dataset/usgs-national-watershed-boundary-dataset-wbd-
              downloadable-data-collection-national-geospatial-/resource/f55f881d-9de8-471f-9b6b-22cd7a98025d

XML: https://services.nationalmap.gov/arcgis/services/nhd/MapServer/WMSServer?request=GetCapabilities&service=WMS
